### PR TITLE
Install sdformat and ignition python math in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         python: ['3.8', '3.9', '3.10']
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout
@@ -16,6 +16,16 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python }}
+    - name: Install dependencies
+      run: |
+        apt-get update
+        apt-get install -y git
+        git clone --depth 1 https://github.com/osrf/gzdev /tmp/gzdev
+        pip3 install -r /tmp/gzdev/requirements.txt
+        /tmp/gzdev/gzdev.py repository enable osrf stable
+        /tmp/gzdev/gzdev.py repository enable osrf nightly
+        apt-get update
+        apt-get install -y libsdformat13-dev python3-ignition-math7
     - name: Install test dependencies
       run: python3 -m pip install -U tox
     - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y git
         git clone --depth 1 https://github.com/osrf/gzdev /tmp/gzdev
-        pip3 install -r /tmp/gzdev/requirements.txt
+        sudo pip3 install -r /tmp/gzdev/requirements.txt
         sudo /tmp/gzdev/gzdev.py repository enable osrf stable
         sudo /tmp/gzdev/gzdev.py repository enable osrf nightly
         sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
         sudo apt-get install -y git
         git clone --depth 1 https://github.com/osrf/gzdev /tmp/gzdev
         pip3 install -r /tmp/gzdev/requirements.txt
-        /tmp/gzdev/gzdev.py repository enable osrf stable
-        /tmp/gzdev/gzdev.py repository enable osrf nightly
+        sudo /tmp/gzdev/gzdev.py repository enable osrf stable
+        sudo /tmp/gzdev/gzdev.py repository enable osrf nightly
         sudo apt-get update
         sudo apt-get install -y libsdformat13-dev python3-ignition-math7
     - name: Install test dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,14 @@ jobs:
         python-version: ${{ matrix.python }}
     - name: Install dependencies
       run: |
-        apt-get update
-        apt-get install -y git
+        sudo apt-get update
+        sudo apt-get install -y git
         git clone --depth 1 https://github.com/osrf/gzdev /tmp/gzdev
         pip3 install -r /tmp/gzdev/requirements.txt
         /tmp/gzdev/gzdev.py repository enable osrf stable
         /tmp/gzdev/gzdev.py repository enable osrf nightly
-        apt-get update
-        apt-get install -y libsdformat13-dev python3-ignition-math7
+        sudo apt-get update
+        sudo apt-get install -y libsdformat13-dev python3-ignition-math7
     - name: Install test dependencies
       run: python3 -m pip install -U tox
     - name: Test


### PR DESCRIPTION
Install stable + nightly repos via gzdev. Install sdformat13 and python3-ignition-math7 packages from nightly.

Need to restrict the CI to Linux for obvious reasons :)
